### PR TITLE
Clamp progress bar

### DIFF
--- a/simple_youtube_api/Channel.py
+++ b/simple_youtube_api/Channel.py
@@ -238,7 +238,10 @@ def resumable_upload(request):
             while response is None:
                 status, response = request.next_chunk(num_retries=4)
                 if status:
-                    bar.update(100 * 10 * status.progress() + 1)
+                    progress = 100 * 10 * status.progress() + 1
+                    if progress > 1000:
+                        progress = 1000
+                    bar.update(progress)
             bar.finish()
             if "id" in response:
                 youtube_video = YouTubeVideo(response["id"])

--- a/simple_youtube_api/Channel.py
+++ b/simple_youtube_api/Channel.py
@@ -238,10 +238,7 @@ def resumable_upload(request):
             while response is None:
                 status, response = request.next_chunk(num_retries=4)
                 if status:
-                    progress = 100 * 10 * status.progress() + 1
-                    if progress > 1000:
-                        progress = 1000
-                    bar.update(progress)
+                    bar.update(min(1000, 100 * 10 * status.progress() + 1))
             bar.finish()
             if "id" in response:
                 youtube_video = YouTubeVideo(response["id"])


### PR DESCRIPTION
In the last days, i've experienced a bug that would cause uploads to crash at nearly 100%:
```
Upload:  99% |/                                                                                            | ETA:   0:00:00   1.9 B/s[2020-05-28 09:17:46] fetch/upload                     Exception while fetching/uploading!
Traceback (most recent call last):                                                                                                                                
  File "main.py", line 69, in fetch_and_upload                                                                                       
    youtube_id = youtube.upload(file, v["title"], v["published"])                                                                
  File "/home/mcofficer/projects/testing/youtube.py", line 51, in upload                                         
    youtube_video = channel.upload_video(video)                                                                                      
  File "/home/mcofficer/projects/testing/venv/lib/python3.6/site-packages/simple_youtube_api/Channel.py", line 120, in upload_video
    youtube_video = initialize_upload(self.channel, video)                                                                           
  File "/home/mcofficer/projects/testing/venv/lib/python3.6/site-packages/simple_youtube_api/Channel.py", line 201, in initialize_upload      
    return resumable_upload(insert_request)                                                                                          
  File "/home/mcofficer/projects/testing/venv/lib/python3.6/site-packages/simple_youtube_api/Channel.py", line 227, in resumable_upload
    bar.update(100 * 10 * status.progress() + 1)                                                                                     
  File "/home/mcofficer/projects/testing/venv/lib/python3.6/site-packages/progressbar/bar.py", line 663, in update
    % (value, self.min_value, self.max_value))                                                                                       
ValueError: Value 1000.1649304027159 is out of range, should be between 0 and 1000
```
I don't know why *exactly* this happens, but it's probably some wacky floating point conversion here:
https://github.com/jonnekaunisto/simple-youtube-api/blob/bb170e6ca3d5786f5f7f564262fc272b60f500a7/simple_youtube_api/Channel.py#L241

No matter the cause, this PR introduces an extra check that clamps the value to 1000 if necessary.