### PR TITLE
Add videos to playlist in the order they are uploaded.

### DIFF
--- a/simple_youtube_api/channel.py
+++ b/simple_youtube_api/channel.py
@@ -201,7 +201,6 @@ class Channel():
             body={
                 "snippet": {
                     "playlistId": playlist_id,
-                    "position": 0,
                     "resourceId": {
                         "kind": "youtube#video",
                         "videoId": video_id


### PR DESCRIPTION
Position is an optional parameter:
https://developers.google.com/youtube/v3/docs/playlistItems/insert#request-body

By not specifying position, videos can be added to playlists in the order they're uploaded which is probably more intuitive for most cases.  Currently, specifying insertion at position 0 adds videos to playlist in reverse order.