### PR TITLE
Fix bug while uploading thumbnails or setting playlists

### DIFF
--- a/simple_youtube_api/channel.py
+++ b/simple_youtube_api/channel.py
@@ -172,9 +172,9 @@ class Channel():
               Path to the thumbnail
         """
         if isinstance(video, str):
-            video_id = video.id
-        else:
             video_id = video
+        else:
+            video_id = video.id
 
         response = self.channel.thumbnails().set(
             videoId=video_id, media_body=thumbnail_path
@@ -192,9 +192,9 @@ class Channel():
         """
 
         if isinstance(video, str):
-            video_id = video.id
-        else:
             video_id = video
+        else:
+            video_id = video.id
 
         response = self.channel.playlistItems().insert(
             part="snippet",


### PR DESCRIPTION
The commit 3d28bedbaf03759161dbd4d9d27e011ac4bd9025 introduces a new bug because the refactoring drops a negation in the expression. Now it will use the video if it is a string and otherwise tries to fetch the id from the video object correctly as before.